### PR TITLE
fix: integer-like extensions are incorrectly converted to integers

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -335,6 +335,6 @@ class Type implements TypeInterface
                 $extensions[$e] = $e;
             }
         }
-        return array_keys($extensions);
+        return array_values($extensions);
     }
 }

--- a/tests/src/TypeTest.php
+++ b/tests/src/TypeTest.php
@@ -692,6 +692,9 @@ class TypeTest extends MimeMapTestBase
         $this->assertEquals(['pgp', 'gpg', 'asc', 'skr', 'pkr', 'key', 'sig'], (new Type('application/pgp*'))->getExtensions());
         $this->assertEquals(['asc', 'sig', 'pgp', 'gpg'], (new Type('application/pgp-s*'))->getExtensions());
 
+        $this->assertEquals(['123', 'wk1', 'wk3', 'wk4', 'wks'], (new Type('application/vnd.lotus-1-2-3'))->getExtensions());
+        $this->assertEquals(['602'], (new Type('application/x-t602'))->getExtensions());
+
         $this->assertSame(['smi', 'smil', 'sml', 'kino'], (new Type('application/smil+xml'))->getExtensions());
         $this->assertSame(['smi', 'smil', 'sml', 'kino'], (new Type('application/smil'))->getExtensions());
     }


### PR DESCRIPTION
Integer-like strings (e.x., `"1"`) that are used as array keys are automatically converted to integers by PHP [per this bug report](https://bugs.php.net/bug.php?id=45348).

This poses an issue for specific extension values that are integer-like strings, as the `getDefaultExtension` method must return a `string` value. Following are two examples where this automatic type conversion results in a `TypeError: FileEye\MimeMap\Type::getDefaultExtension(): Return value must be of type string, int returned`:

1. The default extension for mimetype `application/vnd.lotus-1-2-3` is string value `"123"` which, as an array key, is converted to integer value `123` by PHP.
2. The default extension for mimetype `application/x-t602` is string value `"602"` which, as an array key, is converted to integer value `602` by PHP.

To preserve the extension's string type and resolve this issue, this PR proposes using `array_values` instead of `array_keys` when returning from the `getExtension` method.